### PR TITLE
Allow running 3D detector from binary data of 2D detector

### DIFF
--- a/src/pupil_detectors/c_types_wrapper.pxd
+++ b/src/pupil_detectors/c_types_wrapper.pxd
@@ -14,6 +14,7 @@ from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libc.stdint cimport int32_t
+from libcpp.string cimport string
 
 
 cdef extern from '<opencv2/core.hpp>':
@@ -96,6 +97,7 @@ cdef extern from 'common/types.h':
         double timestamp
         int image_width
         int image_height
+        string serialize()
 
     cdef struct ModelDebugProperties:
         Sphere[double] sphere
@@ -172,6 +174,7 @@ cdef extern from "singleeyefitter/EyeModelFitter.h" namespace "singleeyefitter":
         EyeModelFitter(double focalLength )
 
         Detector3DResult updateAndDetect( shared_ptr[Detector2DResult]& results, const Detector3DProperties& prop, bint fillDebugResult )
+        Detector3DResult updateAndDetectFromBinary(const string&, double, const Detector3DProperties& prop, bint fillDebugResult )
 
         void reset()
         double getFocalLength()

--- a/src/pupil_detectors/detector_2d/detector_2d.pyx
+++ b/src/pupil_detectors/detector_2d/detector_2d.pyx
@@ -117,7 +117,9 @@ cdef class Detector2DCore(DetectorBase):
         cppResultPtr = self.c_detect(gray_img, color_img, roi)
         result = deref(cppResultPtr)
 
-        return result2D_to_dict(result)
+        result_dict = result2D_to_dict(result)
+        result_dict["internal_2d_raw_data"] = result.serialize()
+        return result_dict
 
 
     cdef shared_ptr[Detector2DResult] c_detect(

--- a/src/shared_cpp/include/common/types.h
+++ b/src/shared_cpp/include/common/types.h
@@ -76,39 +76,39 @@ namespace singleeyefitter {
         {
             std::stringstream ss;
         
-            ss.write((const char*)&confidence, sizeof(double));
+            ss.write(reinterpret_cast<const char*>(&confidence), sizeof(double));
 
-            ss.write((const char*)&timestamp, sizeof(double));
+            ss.write(reinterpret_cast<const char*>(&timestamp), sizeof(double));
 
-            ss.write((const char*)&image_width, sizeof(int));
+            ss.write(reinterpret_cast<const char*>(&image_width), sizeof(int));
 
-            ss.write((const char*)&image_height, sizeof(int));
+            ss.write(reinterpret_cast<const char*>(&image_height), sizeof(int));
 
-            ss.write((const char*)&ellipse.center[0], sizeof(double));
-            ss.write((const char*)&ellipse.center[1], sizeof(double));
-            ss.write((const char*)&ellipse.major_radius, sizeof(double));
-            ss.write((const char*)&ellipse.minor_radius, sizeof(double));
-            ss.write((const char*)&ellipse.angle, sizeof(double));
+            ss.write(reinterpret_cast<const char*>(&ellipse.center[0]), sizeof(double));
+            ss.write(reinterpret_cast<const char*>(&ellipse.center[1]), sizeof(double));
+            ss.write(reinterpret_cast<const char*>(&ellipse.major_radius), sizeof(double));
+            ss.write(reinterpret_cast<const char*>(&ellipse.minor_radius), sizeof(double));
+            ss.write(reinterpret_cast<const char*>(&ellipse.angle), sizeof(double));
 
-            ss.write((const char*)&current_roi.x, sizeof(int));
-            ss.write((const char*)&current_roi.y, sizeof(int));
-            ss.write((const char*)&current_roi.width, sizeof(int));
-            ss.write((const char*)&current_roi.height, sizeof(int));
+            ss.write(reinterpret_cast<const char*>(&current_roi.x), sizeof(int));
+            ss.write(reinterpret_cast<const char*>(&current_roi.y), sizeof(int));
+            ss.write(reinterpret_cast<const char*>(&current_roi.width), sizeof(int));
+            ss.write(reinterpret_cast<const char*>(&current_roi.height), sizeof(int));
 
             size_t size = final_edges.size();
-            ss.write((const char*)&size, sizeof(size_t));
+            ss.write(reinterpret_cast<const char*>(&size), sizeof(size_t));
             for (const auto& p : final_edges)
             {
-                ss.write((const char*)&p.x, sizeof(int));
-                ss.write((const char*)&p.y, sizeof(int));
+                ss.write(reinterpret_cast<const char*>(&p.x), sizeof(int));
+                ss.write(reinterpret_cast<const char*>(&p.y), sizeof(int));
             }
 
             size = raw_edges.size();
-            ss.write((const char*)&size, sizeof(size_t));
+            ss.write(reinterpret_cast<const char*>(&size), sizeof(size_t));
             for (const auto& p : raw_edges)
             {
-                ss.write((const char*)&p.x, sizeof(int));
-                ss.write((const char*)&p.y, sizeof(int));
+                ss.write(reinterpret_cast<const char*>(&p.x), sizeof(int));
+                ss.write(reinterpret_cast<const char*>(&p.y), sizeof(int));
             }
             return ss.str();
         }
@@ -117,40 +117,40 @@ namespace singleeyefitter {
         {
             std::stringstream ss(bytes);
 
-            ss.read((char*)&confidence, sizeof(double));
+            ss.read(reinterpret_cast<char*>(&confidence), sizeof(double));
 
-            ss.read((char*)&timestamp, sizeof(double));
+            ss.read(reinterpret_cast<char*>(&timestamp), sizeof(double));
 
-            ss.read((char*)&image_width, sizeof(int));
+            ss.read(reinterpret_cast<char*>(&image_width), sizeof(int));
 
-            ss.read((char*)&image_height, sizeof(int));
+            ss.read(reinterpret_cast<char*>(&image_height), sizeof(int));
 
-            ss.read((char*)&ellipse.center[0], sizeof(double));
-            ss.read((char*)&ellipse.center[1], sizeof(double));
-            ss.read((char*)&ellipse.major_radius, sizeof(double));
-            ss.read((char*)&ellipse.minor_radius, sizeof(double));
-            ss.read((char*)&ellipse.angle, sizeof(double));
+            ss.read(reinterpret_cast<char*>(&ellipse.center[0]), sizeof(double));
+            ss.read(reinterpret_cast<char*>(&ellipse.center[1]), sizeof(double));
+            ss.read(reinterpret_cast<char*>(&ellipse.major_radius), sizeof(double));
+            ss.read(reinterpret_cast<char*>(&ellipse.minor_radius), sizeof(double));
+            ss.read(reinterpret_cast<char*>(&ellipse.angle), sizeof(double));
 
-            ss.read((char*)&current_roi.x, sizeof(int));
-            ss.read((char*)&current_roi.y, sizeof(int));
-            ss.read((char*)&current_roi.width, sizeof(int));
-            ss.read((char*)&current_roi.height, sizeof(int));
+            ss.read(reinterpret_cast<char*>(&current_roi.x), sizeof(int));
+            ss.read(reinterpret_cast<char*>(&current_roi.y), sizeof(int));
+            ss.read(reinterpret_cast<char*>(&current_roi.width), sizeof(int));
+            ss.read(reinterpret_cast<char*>(&current_roi.height), sizeof(int));
 
             size_t size;
-            ss.read((char*)&size, sizeof(size_t));
+            ss.read(reinterpret_cast<char*>(&size), sizeof(size_t));
             final_edges.resize(size);
             for (auto& p : final_edges)
             {
-                ss.read((char*)&p.x, sizeof(int));
-                ss.read((char*)&p.y, sizeof(int));
+                ss.read(reinterpret_cast<char*>(&p.x), sizeof(int));
+                ss.read(reinterpret_cast<char*>(&p.y), sizeof(int));
             }
 
-            ss.read((char*)&size, sizeof(size_t));
+            ss.read(reinterpret_cast<char*>(&size), sizeof(size_t));
             raw_edges.resize(size);
             for (auto& p : raw_edges)
             {
-                ss.read((char*)&p.x, sizeof(int));
-                ss.read((char*)&p.y, sizeof(int));
+                ss.read(reinterpret_cast<char*>(&p.x), sizeof(int));
+                ss.read(reinterpret_cast<char*>(&p.y), sizeof(int));
             }
         }
     };

--- a/src/shared_cpp/include/common/types.h
+++ b/src/shared_cpp/include/common/types.h
@@ -10,6 +10,8 @@
 #include <vector>
 #include <memory>
 #include <chrono>
+#include <string>
+#include <sstream>
 
 #include <opencv2/core.hpp>
 
@@ -66,7 +68,91 @@ namespace singleeyefitter {
         double timestamp = 0.0;
         int image_width = 0;
         int image_height = 0;
+        
+        Detector2DResult() = default;
 
+        public:
+        std::string serialize()
+        {
+            std::stringstream ss;
+        
+            ss.write((const char*)&confidence, sizeof(double));
+
+            ss.write((const char*)&timestamp, sizeof(double));
+
+            ss.write((const char*)&image_width, sizeof(int));
+
+            ss.write((const char*)&image_height, sizeof(int));
+
+            ss.write((const char*)&ellipse.center[0], sizeof(double));
+            ss.write((const char*)&ellipse.center[1], sizeof(double));
+            ss.write((const char*)&ellipse.major_radius, sizeof(double));
+            ss.write((const char*)&ellipse.minor_radius, sizeof(double));
+            ss.write((const char*)&ellipse.angle, sizeof(double));
+
+            ss.write((const char*)&current_roi.x, sizeof(int));
+            ss.write((const char*)&current_roi.y, sizeof(int));
+            ss.write((const char*)&current_roi.width, sizeof(int));
+            ss.write((const char*)&current_roi.height, sizeof(int));
+
+            size_t size = final_edges.size();
+            ss.write((const char*)&size, sizeof(size_t));
+            for (const auto& p : final_edges)
+            {
+                ss.write((const char*)&p.x, sizeof(int));
+                ss.write((const char*)&p.y, sizeof(int));
+            }
+
+            size = raw_edges.size();
+            ss.write((const char*)&size, sizeof(size_t));
+            for (const auto& p : raw_edges)
+            {
+                ss.write((const char*)&p.x, sizeof(int));
+                ss.write((const char*)&p.y, sizeof(int));
+            }
+            return ss.str();
+        }
+
+        Detector2DResult(const std::string& bytes)
+        {
+            std::stringstream ss(bytes);
+
+            ss.read((char*)&confidence, sizeof(double));
+
+            ss.read((char*)&timestamp, sizeof(double));
+
+            ss.read((char*)&image_width, sizeof(int));
+
+            ss.read((char*)&image_height, sizeof(int));
+
+            ss.read((char*)&ellipse.center[0], sizeof(double));
+            ss.read((char*)&ellipse.center[1], sizeof(double));
+            ss.read((char*)&ellipse.major_radius, sizeof(double));
+            ss.read((char*)&ellipse.minor_radius, sizeof(double));
+            ss.read((char*)&ellipse.angle, sizeof(double));
+
+            ss.read((char*)&current_roi.x, sizeof(int));
+            ss.read((char*)&current_roi.y, sizeof(int));
+            ss.read((char*)&current_roi.width, sizeof(int));
+            ss.read((char*)&current_roi.height, sizeof(int));
+
+            size_t size;
+            ss.read((char*)&size, sizeof(size_t));
+            final_edges.resize(size);
+            for (auto& p : final_edges)
+            {
+                ss.read((char*)&p.x, sizeof(int));
+                ss.read((char*)&p.y, sizeof(int));
+            }
+
+            ss.read((char*)&size, sizeof(size_t));
+            raw_edges.resize(size);
+            for (auto& p : raw_edges)
+            {
+                ss.read((char*)&p.x, sizeof(int));
+                ss.read((char*)&p.y, sizeof(int));
+            }
+        }
     };
 
     struct ModelDebugProperties{

--- a/src/singleeyefitter/EyeModelFitter.cpp
+++ b/src/singleeyefitter/EyeModelFitter.cpp
@@ -62,6 +62,12 @@ EyeModelFitter::EyeModelFitter(double focalLength, Vector3 cameraCenter) :
 
 }
 
+Detector3DResult EyeModelFitter::updateAndDetectFromBinary(const std::string& binary, double timestamp, const Detector3DProperties& props , bool debug)
+{
+    auto observation2D = std::make_shared<Detector2DResult>(binary);
+    observation2D->timestamp = timestamp;
+    return updateAndDetect(observation2D, props, debug);
+}
 
 Detector3DResult EyeModelFitter::updateAndDetect(std::shared_ptr<Detector2DResult>& observation2D , const Detector3DProperties& props , bool debug)
 {

--- a/src/singleeyefitter/EyeModelFitter.h
+++ b/src/singleeyefitter/EyeModelFitter.h
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <memory>
+#include <string>
 #include <Eigen/Core>
 
 #include "common/types.h"
@@ -34,7 +35,7 @@ namespace singleeyefitter {
             // this is called with new observations from the 2D detector
             // it decides what happens ,since not all observations are added
             Detector3DResult updateAndDetect( std::shared_ptr<Detector2DResult>& observation,const Detector3DProperties& props, bool debug = false );
-
+            Detector3DResult updateAndDetectFromBinary(const std::string& binary, double timestamp, const Detector3DProperties& props, bool debug = false );
 
         private:
 


### PR DESCRIPTION
This PR allows running the 3D detector without always running the internal 2D detector.

The 2D detector now publishes a binary representation of the `Detector2DResult` struct, which can be fed into the 3D detector, making it re-use the existing `Detector2DResult` and skipping the additional internal 2D detector.

An integration for [Pupil](https://github.com/pupil-labs/pupil) is available in https://github.com/pupil-labs/pupil/pull/1850
This branch however also runs fine with the previous versions of Pupil.