### PR TITLE
Add search locations for opencv on Ubuntu 20.04

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,11 +116,13 @@ else:
         "/usr/local/opt/opencv/include",  # old opencv brew (v3)
         "/usr/local/opt/opencv@3/include",  # new opencv@3 brew
         "/usr/local/include/opencv4",  # new opencv brew (v4)
+        "/usr/include/opencv4",  # opencv (v4) on ubuntu 20.04
     ]
     opencv_library_dirs = [
         "/usr/local/opt/opencv/lib",  # old opencv brew (v3)
         "/usr/local/opt/opencv@3/lib",  # new opencv@3 brew
         "/usr/local/lib",  # new opencv brew (v4)
+        "/usr/lib",  # opencv (v4) on ubuntu 20.04
     ]
     opencv_libraries = [
         "opencv_core",


### PR DESCRIPTION
I couldn't compile on Ubuntu 20.04 since for me OpenCV was not installed in `/usr/local/...` but rather `/usr/...`.

Not sure why this is the case. But applying these changes shouldn't cause any trouble generally?

Should we create a new release from this?