### PR TITLE
Expose focal_length parameter of 3D detector

### DIFF
--- a/src/pupil_detectors/detector_3d/detector_3d.pyx
+++ b/src/pupil_detectors/detector_3d/detector_3d.pyx
@@ -44,14 +44,13 @@ cdef class Detector3DCore(TemporalDetectorBase):
     cdef Detector2DCore detector2D
     cdef EyeModelFitter *detector3DPtr
 
-    def __cinit__(self, *args, **kwargs):
-        focal_length = 620.
+    def __cinit__(self, *args, focal_length=620.0, **kwargs):
         self.detector3DPtr = new EyeModelFitter(focal_length)
         
     def __dealloc__(self):
         del self.detector3DPtr
 
-    def __init__(self, properties=None):
+    def __init__(self, properties=None, *args, **kwargs):
         self.detector2D = Detector2DCore(properties)
 
         # initialize with defaults first and then set_properties to use type checking


### PR DESCRIPTION
The focal length is important for the eye model, but was hard-coded until now.

The actual pupil detection should not have been affected by this, but a wrong eye center would be reported, if the focal length is not correct. Generally this should have still resulted in consistent data, but not when comparing data from two eye cameras with different underlying focal lengths in the same resulting coordinate system.